### PR TITLE
Migrate Object Storage

### DIFF
--- a/2-upload-pictures/upload-pictures.py
+++ b/2-upload-pictures/upload-pictures.py
@@ -1,33 +1,43 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import os
-from swiftclient.service import Connection
 import urllib.request
 import shutil
+import ibm_boto3
+from ibm_botocore.client import Config
 
 def upload():
     try:
-        conn = Connection(key='xxx',
-                          authurl='https://identity.open.softlayer.com/v3',
-                          auth_version='3',
-                          os_options={"project_id": 'xxx',
-                                      "user_id": 'xxx',
-                                      "region_name": 'dallas'}
-                          )       
+        cos = ibm_boto3.resource('s3',
+			ibm_api_key_id='apikey',
+			ibm_service_instance_id='resource_instance_id',
+			ibm_auth_endpoint='https://iam.bluemix.net/oidc/token',
+			config=Config(signature_version='oauth'),
+			endpoint_url='https://s3-api.us-geo.objectstorage.softlayer.net')
 
         zipFileName = 'cozmo-photos' 
-        shutil.make_archive(zipFileName, 'zip', '../take-pictures/pictures')
+        shutil.make_archive(zipFileName, 'zip', '../1-take-pictures/pictures')
         print("Done: Zipping Pictures") 
 
         container = 'tensorflow'
-        conn.put_container(container)
-        resp_headers, containers = conn.get_account()            
+        cos.create_bucket(Bucket=container)            
 
         with open('./' + zipFileName + '.zip', 'rb') as local:            
-            conn.put_object(
+            cos.Object(
                 container,
-                zipFileName + '.zip',
-                contents=local,
-                content_type='application/zip'
-            )  
+                zipFileName + '.zip').upload_file(zipFileName + '.zip')
             print("Done: Uploading Pictures")  
 
     except Exception as e:

--- a/README.md
+++ b/README.md
@@ -18,16 +18,15 @@ The training is done via TensorFlow and a retrained MobileNet model on Kubernete
 
 ![alt text](https://github.com/nheidloff/visual-recognition-for-cozmo-with-tensorflow/raw/master/pictures/architecture-1.png "Training")
 
-The classification is done via Tensorflow running in an [OpenWhisk](https://www.ibm.com/cloud/functions) function.
+The classification is done via TensorFlow running in an [OpenWhisk](https://www.ibm.com/cloud/functions) function.
 
 ![alt text](https://github.com/nheidloff/visual-recognition-for-cozmo-with-tensorflow/raw/master/pictures/architecture-2.png "Classification")
 
 For more details check out the blog entries from Ansgar and me:
 
 * [Sample Application to classify Images with TensorFlow and OpenWhisk](https://heidloff.net/article/visual-recognition-tensorflow)
-* [Accessing IBM Object Store from Python](https://ansi.23-5.eu/2017/11/accessing-ibm-object-store-python/)
-* [Image Recognition with Tensorflow training on Kubernetes](https://ansi.23-5.eu/2017/11/image-recognition-with-tensorflow-training-on-kubernetes/)
-* [Image Recognition with Tensorflow classification on OpenWhisk](https://ansi.23-5.eu/2017/11/image-recognition-tensorflow-classification-openwhisk/)
+* [Image Recognition with TensorFlow training on Kubernetes](https://ansi.23-5.eu/2017/11/image-recognition-with-tensorflow-training-on-kubernetes/)
+* [Image Recognition with TensorFlow classification on OpenWhisk](https://ansi.23-5.eu/2017/11/image-recognition-tensorflow-classification-openwhisk/)
 * [Visual Recognition with TensorFlow and OpenWhisk](http://heidloff.net/article/visual-recognition-tensorflow-openwhisk)
 
 
@@ -59,16 +58,15 @@ $ python3 take-pictures.py deer
 
 ## 2. Upload Pictures
 
-Create an [IBM Object Storage](https://console.bluemix.net/catalog/infrastructure/object-storage-group) instance. Choose the lite Swift option. Read Ansgar's [blog](https://ansi.23-5.eu/2017/11/accessing-ibm-object-store-python/) for details.
+Create an instance of [IBM Cloud Object Storage](https://console.bluemix.net/catalog/services/cloud-object-storage).
 
-Copy/remember the IBM Object Storage credentials: ‘region’, ‘projectId’, ‘userId’ and ‘password’. Paste them in [upload-pictures.py](2-upload-pictures/upload-pictures.py).
+Create a service credential, then copy/remember the fields ‘apikey' and 'resource_instance_id' from the credentials. Paste them in [upload-pictures.py](2-upload-pictures/upload-pictures.py).
 
 Invoke these commands:
 
 ```sh
-$ cd visual-recognition-for-cozmo-with-tensorflow/2-upload-pictures
-$ pip3 install python-swiftclient
-$ pip3 install python-keystoneclient
+$ cd ../visual-recognition-for-cozmo-with-tensorflow/2-upload-pictures
+$ pip3 install ibm-cos-sdk
 $ python3 upload-pictures.py
 ```
 


### PR DESCRIPTION
Support for OpenStack Swift storage has been removed from IBM
Cloud.  Update Step 2 to use IBM Cloud Object Storage