### PR TITLE
Migrate Object Storage, Part II

### DIFF
--- a/3-train/execscript.sh
+++ b/3-train/execscript.sh
@@ -2,14 +2,11 @@
 
 echo ${TF_MODEL}
 
-export OS_AUTH_URL=https://identity.open.softlayer.com/v3
-export OS_IDENTITY_API_VERSION=3
-export OS_AUTH_VERSION=3
+export COS_ENDPOINT=https://s3-api.us-geo.objectstorage.softlayer.net/
 
-swift auth
-swift download ${OS_BUCKET_NAME} ${OS_FILE_NAME}
+aws --endpoint-url=${COS_ENDPOINT} s3 cp s3://${COS_BUCKET_NAME}/${COS_FILE_NAME} ${COS_FILE_NAME}
 
-unzip ${OS_FILE_NAME} -d tf_files/photos
+unzip ${COS_FILE_NAME} -d tf_files/photos
 
 python -m scripts.retrain                            \
        --bottleneck_dir=tf_files/bottlenecks         \
@@ -23,5 +20,6 @@ python -m scripts.retrain                            \
 
 cd tf_files
 
-swift upload tensorflow retrained_graph_cozmo.pb
-swift upload tensorflow retrained_labels_cozmo.txt
+aws --endpoint-url=${COS_ENDPOINT} s3 cp retrained_graph_cozmo.pb s3://${COS_BUCKET_NAME}/retrained_graph_cozmo.pb
+aws --endpoint-url=${COS_ENDPOINT} s3 cp retrained_labels_cozmo.txt s3://${COS_BUCKET_NAME}/retrained_labels_cozmo.txt
+

--- a/3-train/requirements.txt
+++ b/3-train/requirements.txt
@@ -1,2 +1,1 @@
-python-swiftclient==3.4.0
-python-keystoneclient==3.13.0
+awscli==1.16.13

--- a/3-train/train.yml
+++ b/3-train/train.yml
@@ -9,17 +9,13 @@ spec:
       image: nheidloff/tensorflow-openwhisk-train-cozmo:latest
       imagePullPolicy: Always
       env:
-      - name: OS_USER_ID
-        value: xxxx 
-      - name: OS_PASSWORD
-        value: xxxx
-      - name: OS_PROJECT_ID
-        value: xxxxxxx 
-      - name: OS_REGION_NAME
-        value: dallas
-      - name: OS_BUCKET_NAME
+      - name: AWS_ACCESS_KEY_ID
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - name: AWS_SECRET_ACCESS_KEY
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - name: COS_BUCKET_NAME
         value: tensorflow
-      - name: OS_FILE_NAME
+      - name: COS_FILE_NAME
         value: cozmo-photos.zip
       - name: TF_MODEL
         value: mobilenet_0.50_224   # inception_v3, mobilenet_0.50_224, mobilenet_0.50_128, mobilenet_0.50_16

--- a/4-classify/openwhisk-api/api.js
+++ b/4-classify/openwhisk-api/api.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 var str = require('string-to-stream');
 var multipart = require('parted').multipart;
 var fs = require('fs');

--- a/4-classify/requirements.txt
+++ b/4-classify/requirements.txt
@@ -1,3 +1,2 @@
 Flask==0.12
-python-swiftclient==3.4.0
-python-keystoneclient==3.13.0
+ibm-cos-sdk==2.1.3

--- a/5-test-in-web-app/server.js
+++ b/5-test-in-web-app/server.js
@@ -1,4 +1,20 @@
 #! /usr/bin/env node
+/**
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 require('dotenv').config({silent: true});

--- a/NOTICE
+++ b/NOTICE
@@ -7,8 +7,6 @@ The following projects/libraries are used in the Python code but not included in
 
 https://github.com/googlecodelabs/tensorflow-for-poets-2 - Apache License 2.0
 https://github.com/tensorflow - Apache License 2.0
-https://github.com/openstack/python-swiftclient - Apache License 2.0
-https://github.com/openstack/python-keystoneclient - Apache License 2.0
 https://flask.pocoo.org/ - BSD Licence
 https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker - Apache License 2.0
 https://github.com/anki/cozmo-python-sdk - Apache License 2.0


### PR DESCRIPTION
Support for OpenStack Swift storage has been removed from IBM
Cloud.  Update Steps 3, 4 and 5 of the README to use IBM Cloud
Object Storage.